### PR TITLE
Add version field to fhir

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ module "healthcare" {
   }]
   fhir_stores = [{
     name         = "example-fhir-store"
+    version      = "R4"
     notification_config = {
       pubsub_topic = "projects/<PROJECT_ID>/topics/example_topic"
     }

--- a/examples/simple_example/main.tf
+++ b/examples/simple_example/main.tf
@@ -44,7 +44,8 @@ module "healthcare" {
   ]
   fhir_stores = [
     {
-      name = "example-fhir"
+      name    = "example-fhir"
+      version = "R4"
       notification_config = {
         pubsub_topic = "projects/${var.project}/topics/${var.pubsub_topic}"
       }

--- a/main.tf
+++ b/main.tf
@@ -28,14 +28,17 @@ resource "google_healthcare_dicom_store" "dicom_stores" {
     for s in var.dicom_stores :
     s.name => s
   }
-  name = each.value.name
+
+  name    = each.value.name
+  dataset = google_healthcare_dataset.dataset.id
+
   dynamic "notification_config" {
     for_each = lookup(each.value, "notification_config", null) != null ? [each.value.notification_config] : []
     content {
       pubsub_topic = lookup(each.value.notification_config, "pubsub_topic", "")
     }
   }
-  dataset = google_healthcare_dataset.dataset.id
+
 }
 
 resource "google_healthcare_fhir_store" "fhir_stores" {
@@ -44,14 +47,17 @@ resource "google_healthcare_fhir_store" "fhir_stores" {
     for s in var.fhir_stores :
     s.name => s
   }
-  name = each.value.name
+
+  name    = each.value.name
+  dataset = google_healthcare_dataset.dataset.id
+  version = each.value.version
+
   dynamic "notification_config" {
     for_each = lookup(each.value, "notification_config", null) != null ? [each.value.notification_config] : []
     content {
       pubsub_topic = lookup(each.value.notification_config, "pubsub_topic", "")
     }
   }
-  dataset = google_healthcare_dataset.dataset.id
 }
 
 resource "google_healthcare_hl7_v2_store" "hl7_v2_stores" {
@@ -60,12 +66,14 @@ resource "google_healthcare_hl7_v2_store" "hl7_v2_stores" {
     for s in var.hl7_v2_stores :
     s.name => s
   }
-  name = each.value.name
+
+  name    = each.value.name
+  dataset = google_healthcare_dataset.dataset.id
+
   dynamic "notification_config" {
     for_each = lookup(each.value, "notification_config", null) != null ? [each.value.notification_config] : []
     content {
       pubsub_topic = lookup(each.value.notification_config, "pubsub_topic", "")
     }
   }
-  dataset = google_healthcare_dataset.dataset.id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -61,9 +61,11 @@ variable "dicom_stores" {
   default     = []
 }
 
+# Extra fields for fhir_stores:
+#  version: string (required)
 variable "fhir_stores" {
   type        = any
-  description = "Datastore that conforms to the FHIR (https://www.hl7.org/fhir/STU3/) standard for Healthcare information exchange."
+  description = "Datastore that conforms to the FHIR standard for Healthcare information exchange."
   default     = []
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -16,4 +16,7 @@
 
 terraform {
   required_version = ">= 0.12"
+  required_providers {
+    google-beta = ">= 3.10.0"
+  }
 }


### PR DESCRIPTION
The FHIR standard is not stable. There are already 4 revisions out and the current default is not the latest. Future GA API will likely make the version a required field so pre-emptively add the version field as required here.

https://www.hl7.org/fhir/versions.html
"The next major publication of FHIR will be Release 5."

Need to wait for https://github.com/GoogleCloudPlatform/magic-modules/pull/3132 to be merged in first and then set the required provider release as appropriate.