### PR TITLE
Use google-beta for FHIR stores to support beta only feature.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,6 +52,8 @@ resource "google_healthcare_dicom_store" "dicom_stores" {
 }
 
 resource "google_healthcare_fhir_store" "fhir_stores" {
+  provider = google-beta
+
   for_each = {
     for s in var.fhir_stores :
     s.name => s


### PR DESCRIPTION
For V2 analytics schema.