### PR TITLE
Revert "feat: add support for enableHistoryModifications (#93)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ These sections describe requirements for using this module.
 The following dependencies must be available:
 
 - [Terraform][terraform] v0.13
-- [Terraform Provider for GCP][terraform-provider-gcp] plugin 5.13.0
+- [Terraform Provider for GCP][terraform-provider-gcp] plugin v4.76.0
 
 ### Service Account
 

--- a/examples/simple_example/main.tf
+++ b/examples/simple_example/main.tf
@@ -87,7 +87,6 @@ module "healthcare" {
       disable_referential_integrity       = false
       disable_resource_versioning         = false
       enable_history_import               = false
-      enable_history_modifications        = false
       complex_data_type_reference_parsing = "DISABLED"
 
       notification_configs = [{

--- a/examples/simple_example/versions.tf
+++ b/examples/simple_example/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.13.0"
+      version = ">= 4.76.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.13.0"
+      version = ">= 4.76.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,6 @@ resource "google_healthcare_fhir_store" "fhir_stores" {
   disable_resource_versioning         = lookup(each.value, "disable_resource_versioning", null)
   enable_history_import               = lookup(each.value, "enable_history_import", null)
   complex_data_type_reference_parsing = lookup(each.value, "complex_data_type_reference_parsing", null)
-  enable_history_modifications        = lookup(each.value, "enable_history_modifications", null)
 
   dynamic "notification_config" {
     for_each = lookup(each.value, "notification_config", null) != null ? [each.value.notification_config] : []

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.13.0"
+      version = ">= 4.76.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.13.0"
+      version = ">= 4.76.0"
     }
   }
 }


### PR DESCRIPTION
This reverts commit 34670c9edff1b0cad3947b1477b3d97c645c9d4d since we are not able to upgrade the google-beta provider version to use this field.