### PR TITLE
feat: add validation_config support for FHIR stores

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -110,6 +110,17 @@ resource "google_healthcare_fhir_store" "fhir_stores" {
       }
     }
   }
+
+  dynamic "validation_config" {
+    for_each = lookup(each.value, "validation_config", null) != null ? [each.value.validation_config] : []
+    content {
+      disable_profile_validation        = lookup(validation_config.value, "disable_profile_validation", null)
+      enabled_implementation_guides     = lookup(validation_config.value, "enabled_implementation_guides", null)
+      disable_required_field_validation = lookup(validation_config.value, "disable_required_field_validation", null)
+      disable_reference_type_validation = lookup(validation_config.value, "disable_reference_type_validation", null)
+      disable_fhirpath_validation       = lookup(validation_config.value, "disable_fhirpath_validation", null)
+    }
+  }
 }
 
 resource "google_healthcare_hl7_v2_store" "hl7_v2_stores" {


### PR DESCRIPTION
Closes #127

## Description

Adds support for the `validation_config` block on `google_healthcare_fhir_store` resources. This block is supported by the Google provider but was not exposed by the module.

Without this, FHIR stores that have `validation_config` set (via the API, console, or provider defaults) experience config drift on module upgrades — Terraform plans to remove the block, which can unintentionally re-enable validation.

## Change

Added a `dynamic "validation_config"` block to the `google_healthcare_fhir_store` resource in `main.tf`, following the same pattern as the existing `notification_config` block.

### Supported attributes

- `disable_profile_validation` (bool)
- `enabled_implementation_guides` (list of strings)
- `disable_required_field_validation` (bool)
- `disable_reference_type_validation` (bool)
- `disable_fhirpath_validation` (bool)

### Usage

```hcl
fhir_stores = [
  {
    name    = "my-fhir-store"
    version = "R4"
    validation_config = {
      disable_profile_validation        = true
      disable_required_field_validation = true
      disable_reference_type_validation = true
      disable_fhirpath_validation       = true
    }
  }
]
```

No changes to `variables.tf` are needed since `fhir_stores` is typed as `any`.